### PR TITLE
docs: refine example action

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,7 @@ on:
     - cron: "0 0 * * *" # Runs once daily at midnight
   workflow_dispatch:
 
-<<<<<<< HEAD
-permissions:
-  contents: write
-=======
 permissions: {}
->>>>>>> 2fd6dae (docs: refine example action)
 
 jobs:
   build:


### PR DESCRIPTION
I made several improvements to the example action in the README:
- Added an explanation of the `cron` expression.
- Added explicit permissions. 
  Since the action performs a repository checkout and a commit, the `contents: write` permission is sufficient.
  The permission is set at the job level, with no permissions granted at the workflow level.
- Updated `actions/checkout` to `v6`.
- Correct github actions username and email
