### PR TITLE
fix: add permissions section to sample yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add required permissions to the sample workflow.

Without this addition, the workflow fails with:
```
[no-permissions bd651ff] Update README cards
 1 file changed, 3 insertions(+), 3 deletions(-)
remote: Permission to martin-mfg/martin-mfg.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/martin-mfg/martin-mfg/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```