### PR TITLE
permissions cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Generate stats card
-        uses: readme-tools/github-readme-stats-action@V1.1.0
+        uses: readme-tools/github-readme-stats-action@v1
         with:
           card: stats
           options: username=${{ github.repository_owner }}&show_icons=true
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate top languages card
-        uses: readme-tools/github-readme-stats-action@V1.1.0
+        uses: readme-tools/github-readme-stats-action@v1
         with:
           card: top-langs
           options: username=${{ github.repository_owner }}&layout=compact&langs_count=6
@@ -39,7 +39,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate pin card
-        uses: readme-tools/github-readme-stats-action@V1.1.0
+        uses: readme-tools/github-readme-stats-action@v1
         with:
           card: pin
           options: username=readme-tools&repo=github-readme-stats


### PR DESCRIPTION
- permissions are specified under `jobs` -> `build`, there's no need to mention them at root level too
- currently the "v1" tag still points to the same commit as "v1.0.0". I think either the readme sample should be updated to contain the new "V1.1.0" tag (notice the uppercase "V"), or the "v1" tag should be moved.
  - If you prefer the first option, https://github.com/readme-tools/github-readme-stats?tab=readme-ov-file#github-actions needs to be updated as well.
- just FYI: In the logs there is still a warning "(node:2116) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.". This seems to be an [issue in setup-node](https://github.com/actions/setup-node/issues/1364).