### PR TITLE
security: pin SHA of GitHub Actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,8 +10,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
   update-semver:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: haya14busa/action-update-semver@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: haya14busa/action-update-semver@7d2c558640ea49e798d46539536190aff8c18715 # v1.5.1
         with:
           major_version_tag_only: true
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: "22"
     - name: Install dependencies


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use specific commit SHAs for GitHub Action dependencies, improving security and reliability (see [GitHub - Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)):

- `actions/checkout@v4` → `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
- `actions/setup-node@v4` `actions/setup-node@v6` → `actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0`
- `haya14busa/action-update-semver@v1` → `haya14busa/action-update-semver@7d2c558640ea49e798d46539536190aff8c18715 # v1.5.1`
- `softprops/action-gh-release@v1` → `softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1`
