### PR TITLE
fix: avoid husky warning and dev deps on consumer installs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,10 @@ runs:
       with:
         node-version: "24"
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      # --prod skips devDependencies (husky, vitest, etc.); --ignore-scripts skips the
+      # husky prepare hook, which would otherwise fail since husky isn't installed.
+      # https://github.com/stats-organization/github-readme-stats-action/issues/63
+      run: pnpm install --frozen-lockfile --prod --ignore-scripts
       shell: bash
       working-directory: ${{ github.action_path }}
     - name: Generate card


### PR DESCRIPTION
- Closes #63

---

Add the following arguments to the install script in `action.yml`:

- `--prod` drops devDependencies, so only `@actions/core` and `@stats-organization/github-readme-stats-core` get installed.
- `--ignore-scripts` skips the `prepare` hook, which would otherwise fail because husky is no longer installed.


