### PR TITLE
fix: expose path as a composite action output

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ This action is a recommended deployment option. You can also use [our public Git
 - `token`: GitHub token (PAT or `GITHUB_TOKEN`). For private repo stats, use a [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with `repo` and `read:user` scopes. For any gist, use a PAT with `gist` scope.
 - `core_version`: Version of [GitHub Stats Extended](https://github.com/stats-organization/github-stats-extended) to use internally. When omitted, the action uses the latest 2.x.x version.
 
+## Outputs
+
+- `path`: Path where the SVG file was written, relative to the workspace.
+
 ## Examples
 
 Stats example:

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,7 @@ inputs:
 outputs:
   path:
     description: Path where the SVG file was written.
+    value: ${{ steps.generate.outputs.path }}
 runs:
   using: composite
   steps:
@@ -44,6 +45,7 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
     - name: Generate card
+      id: generate
       run: node ${{ github.action_path }}/index.js
       shell: bash
       env:


### PR DESCRIPTION
The `outputs.path` declaration in action.yml was missing a `value:` mapping,
so consumers always received an empty string regardless of what `setOutput` wrote inside `index.js`.

## Changes

- Map `outputs.path` in `action.yml` to `steps.generate.outputs.path` so the value `index.js` sets
  via `setOutput` actually propagates to consumers
- Add `id: generate` to the "Generate card" step so the output can be referenced
- Document the `path` output in `README.md`
