### PR TITLE
feat: source Node version from `package.json#engines` 

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -7,7 +7,7 @@ description: |
 
 inputs:
   node-version:
-    description: "Explicit node version. Otherwise fallback reading `.nvmrc`"
+    description: "Explicit node version. Otherwise fallback reading `engines.node` in `package.json`"
 
 runs:
   using: composite
@@ -24,11 +24,11 @@ runs:
         cache: "pnpm"
         registry-url: "https://registry.npmjs.org"
 
-    - name: Setup Node.js (via .nvmrc)
+    - name: Setup Node.js (via package.json engines)
       if: ${{ !inputs.node-version }}
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version-file: ".nvmrc"
+        node-version-file: "package.json"
         cache: "pnpm"
         registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,11 @@ permissions: {}
 
 jobs:
   test:
-    name: Test ${{ matrix.node }} on ${{ matrix.os }}
+    name: Test on ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        node: [24]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
@@ -35,8 +34,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          node-version: ${{ matrix.node }}
 
       - name: Run E2E tests
         run: pnpm run test

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,2 @@
+# Source of truth: package.json engines.node — keep this file aligned
 24

--- a/action.yml
+++ b/action.yml
@@ -27,18 +27,21 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Resolve relative path to package.json
+    # pnpm/action-setup's `package_json_file` and setup-node's `node-version-file` are both
+    # resolved relative to $GITHUB_WORKSPACE, but our package.json lives under
+    # ${{ github.action_path }} — convert to a workspace-relative path.
+    - name: Compute workspace-relative package.json path
       id: resolve_path
       run: echo "package_json=$(realpath --relative-to="$GITHUB_WORKSPACE" "${{ github.action_path }}/package.json")" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Install pnpm
-      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
         package_json_file: ${{ steps.resolve_path.outputs.package_json }}
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: "24"
+        node-version-file: ${{ steps.resolve_path.outputs.package_json }}
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "*.{js,jsx,ts,tsx,css,json,jsonc,yaml,yml}": "prettier --write"
   },
   "engines": {
-    "node": ">=24"
+    "node": "24.x"
   }
 }


### PR DESCRIPTION
- Replace hardcoded `node-version: "24"` in `action.yml` with `node-version-file` pointing at the action's `package.json`, so the Node version comes from a single source of truth (`engines.node`).
- Reuse the existing `resolve_path` step output for `node-version-file`: `actions/setup-node` resolves it relative to `$GITHUB_WORKSPACE`,
  same workspace-relative approach as `pnpm/action-setup`'s `package_json_file`.
- Change `engines.node` from `>=24` to `24.x` to avoid silently picking up Node 25+.
- Switch `.github/actions/install-dependencies` to read `node-version-file: "package.json"` and drop the redundant `node: [24]` matrix entry from `ci.yml`.
- `.nvmrc` is now purely a local-dev utility for `nvm use`; added a comment marking `package.json` `engines.node` as the source of truth.

## Additional changes

- correct the `pnpm/action-setup` version comment to its full tag (`v5.0.0`).
